### PR TITLE
Pin to a specific (working) node version in CI build_emscripten job

### DIFF
--- a/.circleci/install_node.sh
+++ b/.circleci/install_node.sh
@@ -5,7 +5,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
-nvm install node
+nvm install v16
 npm install -g npm@latest
 
 echo "Node Version :"  $(node -v)


### PR DESCRIPTION
This fixes the failing CircleCI job when run locally and can be added to your upstream PR